### PR TITLE
Remove chunked payments, switch to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Uses [`createReceiver`](https://interledgerjs.github.io/ilp-protocol-psk2/module
 const { createReceive } = require('ilp-protocol-psk2')
 const receiver = await createReceiver({
   plugin: myLedgerPlugin,
-  paymentHandler: async (params) => {
+  requestHandler: (params) => {
     // Accept all incoming payments
-    const result = await params.accept()
-    console.log('Got payment for:', result.receivedAmount)
+    params.accept()
+    console.log(`Got payment for: ${params.amount} with data: ${params.data.toString()}`)
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 - End-to-End Quoting
 - Single Payments
-- Streaming Payments
 - **(Experimental)** Chunked Payments
 
 ## Installation
@@ -104,9 +103,3 @@ const lastChunkResult = await sendSingleChunk(myLedgerPlugin, {
   lastChunk: true
 })
 ```
-
-### Experimental Chunked Payments
-
-**WARNING:** PSK2 Chunked Payments are experimental. Money can be lost if an error occurs mid-payment or if the exchange rate changes dramatically! This should not be used for payments that are significantly larger than the path's Maximum Payment Size.
-
-See [`sendSourceAmount`](https://interledgerjs.github.io/ilp-protocol-psk2/modules/_sender_.html#sendsourceamount) and [`sendDestinationAmount`](https://interledgerjs.github.io/ilp-protocol-psk2/modules/_sender_.html#senddestinationamount).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,10 @@ import BigNumber from 'bignumber.js'
 export const TYPE_PSK2_CHUNK = 0
 export const TYPE_PSK2_LAST_CHUNK = 1
 export const TYPE_PSK2_FULFILLMENT = 2
-export const TYPE_PSK2_ERROR = 3
+export const TYPE_PSK2_REJECT = 3
+export const TYPE_PSK2_REQUEST = 4
+export const TYPE_PSK2_RESPONSE = 5
+export const TYPE_PSK2_ERROR = 6
 
 // PSK Parameters
 export const PSK_FULFILLMENT_STRING = 'ilp_psk2_fulfillment'

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -5,7 +5,7 @@ import BigNumber from 'bignumber.js'
 import * as Long from 'long'
 import * as constants from './constants'
 
-export interface PskPacket {
+export interface LegacyPskPacket {
   type: number,
   paymentId: Buffer,
   sequence: number,
@@ -14,11 +14,88 @@ export interface PskPacket {
   applicationData?: Buffer
 }
 
+export enum Type {
+  Request = 4,
+  Response = 5,
+  Error = 6
+}
+
+export interface PskRequest {
+  type: Type.Request,
+  requestId: number,
+  amount: BigNumber,
+  data: Buffer
+}
+
+export interface PskResponse {
+  type: Type.Response,
+  requestId: number,
+  amount: BigNumber,
+  data: Buffer
+}
+
+export interface PskError {
+  type: Type.Error,
+  requestId: number,
+  amount: BigNumber,
+  data: Buffer
+}
+
+export function isPskRequest (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskRequest {
+  return pskPacket.type === Type.Request
+}
+export function isPskResponse (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskResponse {
+  return pskPacket.type === Type.Response
+}
+export function isPskError (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskError {
+  return pskPacket.type === Type.Error
+}
+
+export function isLegacyPacket (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is LegacyPskPacket {
+  return pskPacket.type === constants.TYPE_PSK2_CHUNK || pskPacket.type === constants.TYPE_PSK2_LAST_CHUNK
+}
+
+export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskRequest | PskResponse | PskError): Buffer {
+  const {
+    type,
+    requestId,
+    amount,
+    data
+  } = pskPacket
+  assert(Number.isInteger(requestId) && requestId <= constants.MAX_UINT32, 'requestId must be a UInt32')
+  assert(amount instanceof BigNumber && amount.isInteger() && amount.lte(constants.MAX_UINT64), 'amount must be a UInt64')
+
+  const writer = new oer.Writer()
+  writer.writeUInt8(type)
+  writer.writeUInt32(requestId)
+  writer.writeUInt64(bigNumberToHighLow(amount))
+  writer.writeVarOctetString(data)
+  const plaintext = writer.getBuffer()
+
+  const ciphertext = encrypt(sharedSecret, plaintext)
+  return ciphertext
+}
+
+export function deserializePskPacket (sharedSecret: Buffer, buffer: Buffer): PskRequest | PskResponse | PskError {
+  const plaintext = decrypt(sharedSecret, buffer)
+  const reader = oer.Reader.from(plaintext)
+
+  const type = reader.readUInt8()
+  assert(Type[type], 'PSK packet has unexpected type: ' + type)
+
+  return {
+    type,
+    requestId: reader.readUInt32(),
+    amount: highLowToBigNumber(reader.readUInt64()),
+    data: reader.readVarOctetString()
+  }
+}
+
 /**
- * Serialize and encrypt a PSK2 packet.
+ * Serialize and encrypt a Legacy PSK2 packet.
  * The result may be sent as the `data` in an `IlpPrepare`, `IlpFulfill`, or `IlpReject` packet.
  */
-export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskPacket): Buffer {
+export function serializeLegacyPskPacket (sharedSecret: Buffer, pskPacket: LegacyPskPacket): Buffer {
   const {
     type,
     paymentId,
@@ -51,9 +128,9 @@ export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskPacket):
 }
 
 /**
- * Decrypt and deserialize a PSK2 packet.
+ * Decrypt and deserialize a Legacy PSK2 packet.
  */
-export function deserializePskPacket (sharedSecret: Buffer, ciphertext: Buffer): PskPacket {
+export function deserializeLegacyPskPacket (sharedSecret: Buffer, ciphertext: Buffer): LegacyPskPacket {
   const contents = decrypt(sharedSecret, ciphertext)
   const reader = new oer.Reader(contents)
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -20,42 +20,14 @@ export enum Type {
   Error = 6
 }
 
-export interface PskRequest {
-  type: Type.Request,
+export interface PskPacket {
+  type: Type,
   requestId: number,
   amount: BigNumber,
   data: Buffer
 }
 
-export interface PskResponse {
-  type: Type.Response,
-  requestId: number,
-  amount: BigNumber,
-  data: Buffer
-}
-
-export interface PskError {
-  type: Type.Error,
-  requestId: number,
-  amount: BigNumber,
-  data: Buffer
-}
-
-export function isPskRequest (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskRequest {
-  return pskPacket.type === Type.Request
-}
-export function isPskResponse (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskResponse {
-  return pskPacket.type === Type.Response
-}
-export function isPskError (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is PskError {
-  return pskPacket.type === Type.Error
-}
-
-export function isLegacyPacket (pskPacket: PskRequest | PskResponse | PskError | LegacyPskPacket): pskPacket is LegacyPskPacket {
-  return pskPacket.type === constants.TYPE_PSK2_CHUNK || pskPacket.type === constants.TYPE_PSK2_LAST_CHUNK
-}
-
-export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskRequest | PskResponse | PskError): Buffer {
+export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskPacket): Buffer {
   const {
     type,
     requestId,
@@ -76,7 +48,7 @@ export function serializePskPacket (sharedSecret: Buffer, pskPacket: PskRequest 
   return ciphertext
 }
 
-export function deserializePskPacket (sharedSecret: Buffer, buffer: Buffer): PskRequest | PskResponse | PskError {
+export function deserializePskPacket (sharedSecret: Buffer, buffer: Buffer): PskPacket {
   const plaintext = decrypt(sharedSecret, buffer)
   const reader = oer.Reader.from(plaintext)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,6 @@ export * from './encoding'
 export {
   TYPE_PSK2_CHUNK,
   TYPE_PSK2_LAST_CHUNK,
-  TYPE_PSK2_ERROR,
+  TYPE_PSK2_REJECT,
   TYPE_PSK2_FULFILLMENT
 } from './constants'

--- a/src/receiver.ts
+++ b/src/receiver.ts
@@ -11,11 +11,8 @@ import * as constants from './constants'
 import * as encoding from './encoding'
 import { dataToFulfillment, fulfillmentToCondition } from './condition'
 import * as ILDCP from 'ilp-protocol-ildcp'
-import { deprecate } from 'util'
 
-const RECEIVER_ID_STRING = 'ilp_psk2_receiver_id'
 const PSK_GENERATION_STRING = 'ilp_psk2_generation'
-const RECEIVER_ID_LENGTH = 8
 const TOKEN_LENGTH = 18
 const SHARED_SECRET_LENGTH = 32
 
@@ -192,7 +189,8 @@ export class Receiver {
   /**
    * @deprecated. Switch to [`registerRequestHandler`]{@link Receiver.registerRequestHandler} instead
    */
-  registerPaymentHandler = deprecate((handler: PaymentHandler): void => {
+  registerPaymentHandler (handler: PaymentHandler): void {
+    console.warn('DeprecationWarning: registerPaymentHandler is deprecated and will be removed in the next version. Use registerRequestHandler instead')
     if (this.usingRequestHandlerApi) {
       throw new Error('PaymentHandler and RequestHandler APIs cannot be used at the same time')
     }
@@ -200,7 +198,7 @@ export class Receiver {
     /* tslint:disable-next-line:strict-type-predicates */
     assert(typeof handler === 'function', 'payment handler must be a function')
     this.paymentHandler = handler
-  }, 'Receiver.registerPaymentHandler is deprecated and will be removed in the next version. Switch to Receiver.registerRequestHandler instead')
+  }
 
   /**
    * @deprecated. Use RequestHandlers instead
@@ -395,7 +393,7 @@ export class Receiver {
         return this.reject('F05', 'Condition generated does not match prepare')
       }
 
-      const { fulfill, responseData } = await this.callRequestHandler(packet.sequence, prepare.amount, Buffer.alloc(0))
+      const { fulfill } = await this.callRequestHandler(packet.sequence, prepare.amount, Buffer.alloc(0))
       if (fulfill) {
         return IlpPacket.serializeIlpFulfill({
           fulfillment,

--- a/src/sender.ts
+++ b/src/sender.ts
@@ -225,11 +225,18 @@ export async function sendRequest (plugin: PluginV2, params: SendRequestParams):
     } else {
       try {
         debug(`sending a legacy single chunk for request: ${requestId}`)
+        // If the data is exactly 20 bytes, assume it is the paymentId and sequence for compatbility purposes
+        let id: Buffer
+        if (Buffer.isBuffer(params.data) && (params.data.length === 20 || params.data.length === 16)) {
+          id = params.data.slice(0, 16)
+        } else {
+          id = Buffer.alloc(16, 0)
+        }
         const result = await sendSingleChunk(plugin, {
+          id,
           destinationAccount: params.destinationAccount,
           sharedSecret: params.sharedSecret,
           sourceAmount: params.sourceAmount,
-          id: Buffer.alloc(16),
           sequence: requestId,
           minDestinationAmount: params.minDestinationAmount,
           lastChunk: false

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,6 +18,8 @@ describe('Exports', function () {
   it('exports the packet types and encoding functions', function () {
     assert.typeOf(PSK2.deserializePskPacket, 'function')
     assert.typeOf(PSK2.serializePskPacket, 'function')
+    assert.typeOf(PSK2.deserializeLegacyPskPacket, 'function')
+    assert.typeOf(PSK2.serializeLegacyPskPacket, 'function')
     assert.typeOf(PSK2.TYPE_PSK2_CHUNK, 'number')
   })
 })

--- a/test/mocks/plugin.ts
+++ b/test/mocks/plugin.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import * as IlpPacket from 'ilp-packet'
 import BigNumber from 'bignumber.js'
+import * as ILDCP from 'ilp-protocol-ildcp'
 
 export interface DataHandler {
   (data: Buffer): Promise<Buffer>
@@ -42,6 +43,13 @@ export default class MockPlugin extends EventEmitter {
   async sendData (data: Buffer): Promise<Buffer> {
     if (data[0] === IlpPacket.Type.TYPE_ILP_PREPARE) {
       const parsed = IlpPacket.deserializeIlpPrepare(data)
+      if (parsed.destination === 'peer.config') {
+        return ILDCP.serializeIldcpResponse({
+          clientAddress: 'test.receiver',
+          assetScale: 9,
+          assetCode: 'ABC'
+        })
+      }
       const newPacket = IlpPacket.serializeIlpPrepare({
         ...parsed,
         amount: new BigNumber(parsed.amount).times(this.exchangeRate).toString(10)

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -288,6 +288,16 @@ describe('Receiver', function () {
           assert.equal(pskResponse.amount.toString(10), '50')
           assert.equal(pskResponse.data.toString('utf8'), 'yup')
         })
+
+        it('should be okay with exta segments being appended to the destinationAccount', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.accept(Buffer.from('yup'))))
+          this.prepare.destination = this.prepare.destination + '.some.other.stuff'
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpFulfill(response).data)
+          assert.equal(pskResponse.type, 5)
+          assert.equal(pskResponse.amount.toString(10), '50')
+          assert.equal(pskResponse.data.toString('utf8'), 'yup')
+        })
       })
 
       describe('legacy PSK packets', function () {

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -289,6 +289,23 @@ describe('Receiver', function () {
           assert.equal(pskResponse.data.toString('utf8'), 'yup')
         })
 
+        it('should throw an error if the user calls accept and reject', async function () {
+          let threw = false
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => {
+            params.accept(Buffer.from('yup'))
+            try {
+              params.reject(Buffer.from('nope'))
+            } catch (err) {
+              threw = true
+              throw err
+            }
+          })
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpFulfill(response).data)
+          assert.equal(pskResponse.data.toString('utf8'), 'yup')
+          assert.equal(threw, true)
+        })
+
         it('should be okay with exta segments being appended to the destinationAccount', async function () {
           this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.accept(Buffer.from('yup'))))
           this.prepare.destination = this.prepare.destination + '.some.other.stuff'

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -7,7 +7,7 @@ import BigNumber from 'bignumber.js'
 import * as IlpPacket from 'ilp-packet'
 import MockPlugin from './mocks/plugin'
 import { Receiver, createReceiver, PaymentReceived, PaymentHandlerParams, RequestHandlerParams } from '../src/receiver'
-import { quoteSourceAmount, sendSingleChunk } from '../src/sender'
+import { sendRequest, quoteSourceAmount, sendSingleChunk } from '../src/sender'
 import * as encoding from '../src/encoding'
 import * as ILDCP from 'ilp-protocol-ildcp'
 import { MAX_UINT64, TYPE_PSK2_FULFILLMENT, TYPE_PSK2_REJECT } from '../src/constants'
@@ -246,6 +246,21 @@ describe('Receiver', function () {
       describe('valid packets', function () {
         beforeEach(function () {
           this.receiver.deregisterRequestHandler()
+        })
+
+        it('should accept packets sent by sendRequest', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => {
+            params.accept(Buffer.from('thanks!'))
+          })
+          const result = await sendRequest(this.plugin, {
+            destinationAccount: this.destinationAccount,
+            sharedSecret: this.sharedSecret,
+            sourceAmount: '10',
+            minDestinationAmount: '1'
+          })
+          assert.equal(result.fulfilled, true)
+          assert.equal(result.data.toString('utf8'), 'thanks!')
+          assert.equal(result.destinationAmount.toString(10), '5')
         })
 
         it('should call the RequestHandler with the amount and data', async function () {

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -6,10 +6,11 @@ import mock = require('mock-require')
 import BigNumber from 'bignumber.js'
 import * as IlpPacket from 'ilp-packet'
 import MockPlugin from './mocks/plugin'
-import { Receiver, createReceiver, PaymentReceived, PaymentHandlerParams } from '../src/receiver'
+import { Receiver, createReceiver, PaymentReceived, PaymentHandlerParams, RequestHandlerParams } from '../src/receiver'
+import { quoteSourceAmount, sendSingleChunk } from '../src/sender'
 import * as encoding from '../src/encoding'
 import * as ILDCP from 'ilp-protocol-ildcp'
-import { MAX_UINT64 } from '../src/constants'
+import { MAX_UINT64, TYPE_PSK2_FULFILLMENT, TYPE_PSK2_REJECT } from '../src/constants'
 import * as condition from '../src/condition'
 
 describe('Receiver', function () {
@@ -65,7 +66,7 @@ describe('Receiver', function () {
     it('should append the receiver ID and token to the address returned by ILDCP', async function () {
       await this.receiver.connect()
       const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-      assert.match(destinationAccount, /^test\.receiver\.-2ZDreU6l9g\.[a-zA-Z0-9_-]+$/)
+      assert.match(destinationAccount, /^test\.receiver\.[a-zA-Z0-9_-]+$/)
     })
 
     it('should create a unique shared secret every time it is called', async function () {
@@ -77,480 +78,778 @@ describe('Receiver', function () {
     })
   })
 
+  describe('registerRequestHandler', function () {
+    it('should not allow you to register both a request and payment handler', async function () {
+      this.receiver.registerPaymentHandler(() => undefined)
+      assert.throws(() => this.receiver.registerRequestHandler(() => undefined))
+
+      this.receiver.deregisterPaymentHandler()
+      this.receiver.registerRequestHandler(() => undefined)
+      assert.throws(() => this.receiver.registerPaymentHandler(() => undefined))
+    })
+  })
+
   describe('handleData', function () {
     beforeEach(async function () {
       await this.receiver.connect()
     })
 
-    describe('invalid packets', function () {
-      it('should reject if it gets anything other than an IlpPrepare packet', async function () {
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpForwardedPayment({
-          account: 'test.receiver',
-          data: Buffer.alloc(32)
-        }))
-        assert(response)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F06',
-          message: 'Payment is not for this receiver',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
-        })
-      })
-
-      it('should reject if the receiver ID does not match', async function () {
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
-          destination: 'test.receiver.abc12345.sdflkjlskdfj',
-          amount: '1',
-          expiresAt: new Date(2000),
-          executionCondition: Buffer.alloc(32),
-          data: Buffer.alloc(32)
-        }))
-        assert(response)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F06',
-          message: 'Payment is not for this receiver',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
-        })
-      })
-
-      it('should reject if it cannot decrypt the data', async function () {
-        const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
-          destination: destinationAccount,
-          amount: '1',
-          expiresAt: new Date(2000),
-          executionCondition: Buffer.alloc(32),
-          data: Buffer.alloc(32)
-        }))
-        assert(response)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F06',
-          message: 'Unable to parse data',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
-        })
-      })
-
-      it('should reject if it does not know the PSK packet type', async function () {
-        const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
-          destination: destinationAccount,
-          amount: '1',
-          expiresAt: new Date(2000),
-          executionCondition: Buffer.alloc(32),
-          data: encoding.serializePskPacket(sharedSecret, {
-            type: 4,
-            paymentId: Buffer.alloc(16),
-            sequence: 0,
-            paymentAmount: MAX_UINT64,
-            chunkAmount: MAX_UINT64,
-            applicationData: Buffer.alloc(0)
-          })
-        }))
-        assert(response)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F06',
-          message: 'Unexpected request type',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
-        })
-      })
-
-      it('should reject if the prepare amount is lower than the chunk amount specified in the PSK data (and the response should say how much arrived)', async function () {
-        const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
-          destination: destinationAccount,
+    describe('RequestHandler API', function () {
+      beforeEach(function () {
+        this.receiver.registerRequestHandler(() => undefined)
+        const { sharedSecret, destinationAccount } = this.receiver.generateAddressAndSecret()
+        this.sharedSecret = sharedSecret
+        this.destinationAccount = destinationAccount
+        this.pskRequest = {
+          type: encoding.Type.Request,
+          requestId: 1000,
+          amount: new BigNumber(50),
+          data: Buffer.from('hello')
+        }
+        this.pskRequestBuffer = encoding.serializePskPacket(this.sharedSecret, this.pskRequest)
+        this.fulfillment = condition.dataToFulfillment(this.sharedSecret, this.pskRequestBuffer)
+        this.executionCondition = condition.fulfillmentToCondition(this.fulfillment)
+        this.prepare = {
+          destination: this.destinationAccount,
           amount: '100',
-          expiresAt: new Date(2000),
-          executionCondition: Buffer.alloc(32),
-          data: encoding.serializePskPacket(sharedSecret, {
-            type: 0,
-            paymentId: Buffer.alloc(16),
-            sequence: 0,
-            paymentAmount: MAX_UINT64,
-            chunkAmount: MAX_UINT64,
-            applicationData: Buffer.alloc(0)
+          data: this.pskRequestBuffer,
+          executionCondition: this.executionCondition,
+          expiresAt: new Date(Date.now() + 3000)
+        }
+      })
+
+      describe('invalid packets', function () {
+        it('should reject if it gets anything other than an IlpPrepare packet', async function () {
+          this.receiver.registerRequestHandler(() => undefined)
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpForwardedPayment({
+            account: 'test.receiver',
+            data: Buffer.alloc(32)
+          }))
+          assert(response)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Packet is not an IlpPrepare',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
           })
-        }))
-        assert(response)
-        const reject = IlpPacket.deserializeIlpReject(response)
-        assert.equal(reject.code, 'F99')
-        assert.equal(reject.message, '')
-        const pskResponse = encoding.deserializePskPacket(sharedSecret, reject.data)
-        assert.deepEqual(pskResponse, {
-          type: 3,
-          paymentId: Buffer.alloc(16),
-          sequence: 0,
-          paymentAmount: new BigNumber(0),
-          chunkAmount: new BigNumber(50),
-          applicationData: Buffer.alloc(0)
+        })
+
+        it('should reject if the data has been tampered with', async function () {
+          this.prepare.data[10] = ~this.prepare.data[10]
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Unable to parse data',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject if the PSK packet type is unknown', async function () {
+          this.pskRequest.type = 7
+          this.pskRequestBuffer = encoding.serializePskPacket(this.sharedSecret, this.pskRequest)
+          this.fulfillment = condition.dataToFulfillment(this.sharedSecret, this.pskRequestBuffer)
+          this.executionCondition = condition.fulfillmentToCondition(this.fulfillment)
+          this.prepare = {
+            destination: this.destinationAccount,
+            amount: '100',
+            data: this.pskRequestBuffer,
+            executionCondition: this.executionCondition,
+            expiresAt: new Date(Date.now() + 3000)
+          }
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Unable to parse data',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject if the PSK packet is not a request type', async function () {
+          this.pskRequest.type = encoding.Type.Response
+          this.pskRequestBuffer = encoding.serializePskPacket(this.sharedSecret, this.pskRequest)
+          this.fulfillment = condition.dataToFulfillment(this.sharedSecret, this.pskRequestBuffer)
+          this.executionCondition = condition.fulfillmentToCondition(this.fulfillment)
+          this.prepare = {
+            destination: this.destinationAccount,
+            amount: '100',
+            data: this.pskRequestBuffer,
+            executionCondition: this.executionCondition,
+            expiresAt: new Date(Date.now() + 3000)
+          }
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Unexpected packet type',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+          this.plugin.hello = 'foo'
+        })
+
+        it('should reject if the amount received is less than specified in the PSK Request', async function () {
+          // Note: We should be able to use the fixtures attached to this but for some reason this test fails unless these are copied here
+          this.pskRequest = {
+            type: encoding.Type.Request,
+            requestId: 1000,
+            amount: new BigNumber(50),
+            data: Buffer.from('hello')
+          }
+          this.pskRequestBuffer = encoding.serializePskPacket(this.sharedSecret, this.pskRequest)
+          this.fulfillment = condition.dataToFulfillment(this.sharedSecret, this.pskRequestBuffer)
+          this.executionCondition = condition.fulfillmentToCondition(this.fulfillment)
+          this.prepare = {
+            destination: this.destinationAccount,
+            amount: '99',
+            data: this.pskRequestBuffer,
+            executionCondition: this.executionCondition,
+            expiresAt: new Date(Date.now() + 3000)
+          }
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const parsed = IlpPacket.deserializeIlpReject(response)
+          assert.equal(parsed.message, '')
+          assert.equal(parsed.code, 'F99')
+          assert.notEqual(parsed.data.length, 0)
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, parsed.data)
+          assert.equal(pskResponse.requestId, this.pskRequest.requestId)
+          assert.equal(pskResponse.amount.toString(10), '49')
+        })
+
+        it('should reject if it cannot properly generate the fulfillment', async function () {
+          // Note: We should be able to use the fixtures attached to this but for some reason this test fails unless these are copied here
+          this.pskRequest = {
+            type: encoding.Type.Request,
+            requestId: 1000,
+            amount: new BigNumber(50),
+            data: Buffer.from('hello')
+          }
+          this.pskRequestBuffer = encoding.serializePskPacket(this.sharedSecret, this.pskRequest)
+          const executionCondition = Buffer.alloc(32, 0)
+          const prepare = {
+            destination: this.destinationAccount,
+            amount: '100',
+            data: this.pskRequestBuffer,
+            executionCondition,
+            expiresAt: new Date(Date.now() + 3000)
+          }
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(prepare))
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F05',
+            message: 'Condition generated does not match prepare',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
         })
       })
 
-      it('should reject if it cannot regenerate the fulfillment from the PSK data', async function () {
-        const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-        const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
-          destination: destinationAccount,
-          amount: '100',
-          expiresAt: new Date(2000),
-          executionCondition: Buffer.alloc(32),
-          data: encoding.serializePskPacket(sharedSecret, {
-            type: 0,
+      describe('valid packets', function () {
+        beforeEach(function () {
+          this.receiver.deregisterRequestHandler()
+        })
+
+        it('should call the RequestHandler with the amount and data', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerRequestHandler(spy)
+          await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          assert.equal(spy.args[0][0].amount.toString(10), '50')
+          assert.equal(spy.args[0][0].data.toString('utf8'), 'hello')
+        })
+
+        it('should reject the packet if the user calls reject', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => params.reject(Buffer.from('nope')))
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpReject(response).data)
+          assert.equal(pskResponse.amount.toString(10), '50')
+          assert.equal(pskResponse.data.toString('utf8'), 'nope')
+        })
+
+        it('should reject the packet if there is an error thrown in the request handler', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => { throw new Error('oops') })
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpReject(response).data)
+          assert.equal(pskResponse.amount.toString(10), '50')
+          assert.equal(pskResponse.data.toString('utf8'), '')
+        })
+
+        it('should reject the packet if the user does not call accept or reject', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => { return })
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpReject(response).data)
+          assert.equal(pskResponse.amount.toString(10), '50')
+          assert.equal(pskResponse.data.toString('utf8'), '')
+        })
+
+        it('should fulfill packets if the user calls accept', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.accept(Buffer.from('yup'))))
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare(this.prepare))
+          const pskResponse = encoding.deserializePskPacket(this.sharedSecret, IlpPacket.deserializeIlpFulfill(response).data)
+          assert.equal(pskResponse.requestId, this.pskRequest.requestId)
+          assert.equal(pskResponse.amount.toString(10), '50')
+          assert.equal(pskResponse.data.toString('utf8'), 'yup')
+        })
+      })
+
+      describe('legacy PSK packets', function () {
+        it('should reject if the prepare amount is less than the chunkAmount', async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(2000),
+            executionCondition: Buffer.alloc(32),
+            data: encoding.serializeLegacyPskPacket(sharedSecret, {
+              type: 0,
+              paymentId: Buffer.alloc(16),
+              sequence: 0,
+              paymentAmount: MAX_UINT64,
+              chunkAmount: MAX_UINT64,
+              applicationData: Buffer.alloc(0)
+            })
+          }))
+          assert(response)
+          const reject = IlpPacket.deserializeIlpReject(response)
+          assert.equal(reject.code, 'F99')
+          assert.equal(reject.message, '')
+          const pskResponse = encoding.deserializeLegacyPskPacket(sharedSecret, reject.data)
+          assert.deepEqual(pskResponse, {
+            type: 3,
             paymentId: Buffer.alloc(16),
             sequence: 0,
-            paymentAmount: MAX_UINT64,
+            paymentAmount: new BigNumber(0),
             chunkAmount: new BigNumber(50),
             applicationData: Buffer.alloc(0)
           })
-        }))
-        assert(response)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F05',
-          message: 'condition generated does not match prepare',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
+        })
+
+        it('should fulfill with the right PSK packet type if the user calls accept', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.accept(Buffer.from('yup'))))
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const legacy = encoding.serializeLegacyPskPacket(sharedSecret, {
+            type: 1,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: MAX_UINT64,
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(sharedSecret, legacy)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare = IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition,
+            data: legacy
+          })
+          const response = await this.plugin.sendData(prepare)
+          const fulfill = IlpPacket.deserializeIlpFulfill(response)
+          const parsed = encoding.deserializeLegacyPskPacket(sharedSecret, fulfill.data)
+          assert.equal(parsed.type, TYPE_PSK2_FULFILLMENT)
+          assert.equal(parsed.applicationData && parsed.applicationData.toString('utf8'), '')
+        })
+
+        it('should reject with the correct packet type if the user calls reject', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.reject(Buffer.from('nope'))))
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const legacy = encoding.serializeLegacyPskPacket(sharedSecret, {
+            type: 1,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: MAX_UINT64,
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(sharedSecret, legacy)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare = IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition,
+            data: legacy
+          })
+          const response = await this.plugin.sendData(prepare)
+          const reject = IlpPacket.deserializeIlpReject(response)
+          const parsed = encoding.deserializeLegacyPskPacket(sharedSecret, reject.data)
+          assert.equal(parsed.type, TYPE_PSK2_REJECT)
+          assert.equal(parsed.applicationData && parsed.applicationData.toString('utf8'), '')
+        })
+
+        it('should work with quoteSourceAmount', async function () {
+          const { sourceAmount, destinationAmount } = await quoteSourceAmount(this.plugin, {
+            destinationAccount: this.destinationAccount,
+            sharedSecret: this.sharedSecret,
+            sourceAmount: '100'
+          })
+          assert.equal(destinationAmount, '50')
+        })
+
+        it('should work with sendSingleChunk', async function () {
+          this.receiver.registerRequestHandler((params: RequestHandlerParams) => Promise.resolve().then(() => params.accept(Buffer.from('yup'))))
+          const result = await sendSingleChunk(this.plugin, {
+            destinationAccount: this.destinationAccount,
+            sharedSecret: this.sharedSecret,
+            sourceAmount: '100'
+          })
+          assert.equal(result.chunksFulfilled, 1)
         })
       })
     })
 
-    describe('valid one-off packets', function () {
-      beforeEach(function () {
-        const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-        const pskRequest = encoding.serializePskPacket(sharedSecret, {
-          type: 1,
-          paymentId: Buffer.alloc(16),
-          sequence: 0,
-          paymentAmount: MAX_UINT64,
-          chunkAmount: new BigNumber(0),
-          applicationData: Buffer.alloc(0)
+    describe('legacy PaymentHandler API', function () {
+      describe('invalid packets', function () {
+        it('should reject if it gets anything other than an IlpPrepare packet', async function () {
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpForwardedPayment({
+            account: 'test.receiver',
+            data: Buffer.alloc(32)
+          }))
+          assert(response)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Packet is not an IlpPrepare',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
         })
-        this.fulfillment = condition.dataToFulfillment(sharedSecret, pskRequest)
-        const executionCondition = condition.fulfillmentToCondition(this.fulfillment)
-        this.prepare = IlpPacket.serializeIlpPrepare({
-          destination: destinationAccount,
-          amount: '100',
-          expiresAt: new Date(Date.now() + 2000),
-          executionCondition,
-          data: pskRequest
+
+        it('should reject if it cannot decrypt the data', async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '1',
+            expiresAt: new Date(2000),
+            executionCondition: Buffer.alloc(32),
+            data: Buffer.alloc(32)
+          }))
+          assert(response)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Unable to parse data',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject if it does not know the PSK packet type', async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '1',
+            expiresAt: new Date(2000),
+            executionCondition: Buffer.alloc(32),
+            data: encoding.serializeLegacyPskPacket(sharedSecret, {
+              type: 4,
+              paymentId: Buffer.alloc(16),
+              sequence: 0,
+              paymentAmount: MAX_UINT64,
+              chunkAmount: MAX_UINT64,
+              applicationData: Buffer.alloc(0)
+            })
+          }))
+          assert(response)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F06',
+            message: 'Unexpected request type',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject if the prepare amount is lower than the chunk amount specified in the PSK data (and the response should say how much arrived)', async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(2000),
+            executionCondition: Buffer.alloc(32),
+            data: encoding.serializeLegacyPskPacket(sharedSecret, {
+              type: 0,
+              paymentId: Buffer.alloc(16),
+              sequence: 0,
+              paymentAmount: MAX_UINT64,
+              chunkAmount: MAX_UINT64,
+              applicationData: Buffer.alloc(0)
+            })
+          }))
+          assert(response)
+          const reject = IlpPacket.deserializeIlpReject(response)
+          assert.equal(reject.code, 'F99')
+          assert.equal(reject.message, '')
+          const pskResponse = encoding.deserializeLegacyPskPacket(sharedSecret, reject.data)
+          assert.deepEqual(pskResponse, {
+            type: 3,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: new BigNumber(0),
+            chunkAmount: new BigNumber(50),
+            applicationData: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject if it cannot regenerate the fulfillment from the PSK data', async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const response = await this.plugin.sendData(IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(2000),
+            executionCondition: Buffer.alloc(32),
+            data: encoding.serializeLegacyPskPacket(sharedSecret, {
+              type: 0,
+              paymentId: Buffer.alloc(16),
+              sequence: 0,
+              paymentAmount: MAX_UINT64,
+              chunkAmount: new BigNumber(50),
+              applicationData: Buffer.alloc(0)
+            })
+          }))
+          assert(response)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F05',
+            message: 'condition generated does not match prepare',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
         })
       })
 
-      it('should fulfill a payment if the payment handler accepts it', async function () {
-        this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
-          await params.accept()
+      describe('valid one-off packets', function () {
+        beforeEach(function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          const pskRequest = encoding.serializeLegacyPskPacket(sharedSecret, {
+            type: 1,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: MAX_UINT64,
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          this.fulfillment = condition.dataToFulfillment(sharedSecret, pskRequest)
+          const executionCondition = condition.fulfillmentToCondition(this.fulfillment)
+          this.prepare = IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition,
+            data: pskRequest
+          })
         })
-        const response = await this.plugin.sendData(this.prepare)
 
-        assert.equal(response[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-        assert.deepEqual(IlpPacket.deserializeIlpFulfill(response).fulfillment, this.fulfillment)
-      })
+        it('should fulfill a payment if the payment handler accepts it', async function () {
+          this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
+            await params.accept()
+          })
+          const response = await this.plugin.sendData(this.prepare)
 
-      it('should reject payments if the payment handler calls reject', async function () {
-        this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
-          await params.reject('unwanted')
+          assert.equal(response[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.deepEqual(IlpPacket.deserializeIlpFulfill(response).fulfillment, this.fulfillment)
         })
-        const response = await this.plugin.sendData(this.prepare)
 
-        assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F99',
-          message: 'unwanted',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
+        it('should reject payments if the payment handler calls reject', async function () {
+          this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
+            await params.reject('unwanted')
+          })
+          const response = await this.plugin.sendData(this.prepare)
+
+          assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F99',
+            message: 'unwanted',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject payments if there is an error thrown in the payment handler', async function () {
+          this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
+            throw new Error('some error')
+          })
+          const response = await this.plugin.sendData(this.prepare)
+
+          assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F99',
+            message: 'some error',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject payments if the payment handler finishes without accept being called', async function () {
+          this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
+            return
+          })
+          const response = await this.plugin.sendData(this.prepare)
+
+          assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F99',
+            message: 'receiver did not accept the payment',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
+        })
+
+        it('should reject payments if there is no payment handler registered', async function () {
+          this.receiver.deregisterPaymentHandler()
+          const response = await this.plugin.sendData(this.prepare)
+
+          assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
+            code: 'F99',
+            message: 'Receiver has no payment handler registered',
+            triggeredBy: 'test.receiver',
+            data: Buffer.alloc(0)
+          })
         })
       })
 
-      it('should reject payments if there is an error thrown in the payment handler', async function () {
-        this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
-          throw new Error('some error')
+      describe('multiple chunks', function () {
+        beforeEach(async function () {
+          const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
+          this.destinationAccount = destinationAccount
+          this.sharedSecret = sharedSecret
+          const pskRequest1 = encoding.serializeLegacyPskPacket(sharedSecret, {
+            type: 0,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment1 = condition.dataToFulfillment(sharedSecret, pskRequest1)
+          const executionCondition1 = condition.fulfillmentToCondition(fulfillment1)
+          this.prepare1 = IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition1,
+            data: pskRequest1
+          })
+          const pskRequest2 = encoding.serializeLegacyPskPacket(sharedSecret, {
+            type: 0,
+            paymentId: Buffer.alloc(16),
+            sequence: 1,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment2 = condition.dataToFulfillment(sharedSecret, pskRequest2)
+          const executionCondition2 = condition.fulfillmentToCondition(fulfillment2)
+          this.prepare2 = IlpPacket.serializeIlpPrepare({
+            destination: destinationAccount,
+            amount: '200',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition2,
+            data: pskRequest2
+          })
         })
-        const response = await this.plugin.sendData(this.prepare)
 
-        assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F99',
-          message: 'some error',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
+        it('should call the payment handler on the first chunk', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler(spy)
+          await this.plugin.sendData(this.prepare1)
+          assert.typeOf(spy.args[0][0].accept, 'function')
+          assert.typeOf(spy.args[0][0].reject, 'function')
+          assert.typeOf(spy.args[0][0].acceptSingleChunk, 'function')
+          assert.typeOf(spy.args[0][0].rejectSingleChunk, 'function')
+          assert.typeOf(spy.args[0][0].prepare, 'object')
+          assert.equal(spy.args[0][0].prepare.amount, '50')
+          assert(Buffer.isBuffer(spy.args[0][0].id))
         })
-      })
 
-      it('should reject payments if the payment handler finishes without accept being called', async function () {
-        this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
-          return
+        it('should accept the next chunks if the receiver calls accpet', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            params.accept()
+            spy()
+          })
+          const result1 = await this.plugin.sendData(this.prepare1)
+          const result2 = await this.plugin.sendData(this.prepare2)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(spy.callCount, 1)
         })
-        const response = await this.plugin.sendData(this.prepare)
 
-        assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F99',
-          message: 'receiver did not accept the payment',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
+        it('should resolve the Promise returned by the accept function when the payment has been fully received', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
+            const paymentResult = await params.accept()
+            spy(paymentResult)
+          })
+
+          const pskRequest = encoding.serializeLegacyPskPacket(this.sharedSecret, {
+            type: 0,
+            paymentId: Buffer.alloc(16),
+            sequence: 2,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare3 = IlpPacket.serializeIlpPrepare({
+            destination: this.destinationAccount,
+            amount: '1002', // plugin applies 0.5 exchange rate
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition,
+            data: pskRequest
+          })
+
+          const result1 = await this.plugin.sendData(this.prepare1)
+          const result2 = await this.plugin.sendData(this.prepare2)
+          const result3 = await this.plugin.sendData(prepare3)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result3[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+
+          // The payment result promise is resolved without being awaited so it'll only happen on the next tick of the event loop
+          await new Promise((resolve, reject) => setImmediate(resolve))
+
+          assert.equal(spy.callCount, 1)
+          assert.deepEqual(spy.args[0][0], {
+            id: Buffer.alloc(16),
+            chunksFulfilled: 3,
+            chunksRejected: 0,
+            expectedAmount: '500',
+            receivedAmount: '651'
+          })
         })
-      })
 
-      it('should reject payments if there is no payment handler registered', async function () {
-        this.receiver.deregisterPaymentHandler()
-        const response = await this.plugin.sendData(this.prepare)
+        it('should reject all chunks if the receiver calls reject', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            spy()
+            params.reject('nop')
+          })
+          const result1 = await this.plugin.sendData(this.prepare1)
+          const result2 = await this.plugin.sendData(this.prepare2)
 
-        assert.equal(response[0], IlpPacket.Type.TYPE_ILP_REJECT)
-        assert.deepEqual(IlpPacket.deserializeIlpReject(response), {
-          code: 'F99',
-          message: 'Receiver has no payment handler registered',
-          triggeredBy: 'test.receiver',
-          data: Buffer.alloc(0)
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.equal(spy.callCount, 1)
         })
+
+        it('should not accept any more chunks after the payment amount has been received', async function () {
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            params.accept()
+          })
+          const pskRequest = encoding.serializeLegacyPskPacket(this.sharedSecret, {
+            type: 0,
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare = IlpPacket.serializeIlpPrepare({
+            destination: this.destinationAccount,
+            amount: '1002', // plugin applies 0.5 exchange rate
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition,
+            data: pskRequest
+          })
+          const result1 = await this.plugin.sendData(prepare)
+          const result2 = await this.plugin.sendData(this.prepare2)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
+        })
+
+        it('should not accept more chunks after the last chunk has been received', async function () {
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            params.accept()
+          })
+          const pskRequest = encoding.serializeLegacyPskPacket(this.sharedSecret, {
+            type: 1, // last chunk
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare = IlpPacket.serializeIlpPrepare({
+            destination: this.destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition,
+            data: pskRequest
+          })
+          const result1 = await this.plugin.sendData(prepare)
+          const result2 = await this.plugin.sendData(this.prepare2)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
+        })
+
+        it('should accept one chunk and call the payment handler again if the user calls acceptSingleChunk', async function () {
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            params.acceptSingleChunk()
+            spy()
+          })
+          const result1 = await this.plugin.sendData(this.prepare1)
+          const result2 = await this.plugin.sendData(this.prepare2)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(spy.callCount, 2)
+        })
+
+        it('should accept a single-chunk payment if the user calls acceptSingleChunk', async function () {
+          // Previously this would throw because the finishedPromise was only set by the accept method, not acceptSingleChunk
+          const spy = sinon.spy()
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            params.acceptSingleChunk()
+            spy()
+          })
+          const pskRequest = encoding.serializeLegacyPskPacket(this.sharedSecret, {
+            type: 1, // last chunk
+            paymentId: Buffer.alloc(16),
+            sequence: 0,
+            paymentAmount: new BigNumber(500),
+            chunkAmount: new BigNumber(0),
+            applicationData: Buffer.alloc(0)
+          })
+          const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
+          const executionCondition = condition.fulfillmentToCondition(fulfillment)
+          const prepare = IlpPacket.serializeIlpPrepare({
+            destination: this.destinationAccount,
+            amount: '100',
+            expiresAt: new Date(Date.now() + 2000),
+            executionCondition: executionCondition,
+            data: pskRequest
+          })
+          const result1 = await this.plugin.sendData(prepare)
+          assert.equal(spy.callCount, 1)
+        })
+
+        it('should reject one chunk and call the payment handler again if the user calls rejectSingleChunk', async function () {
+          let callCount = 0
+          this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
+            if (++callCount === 1) {
+              params.rejectSingleChunk('nope')
+            } else {
+              params.acceptSingleChunk()
+            }
+          })
+          const result1 = await this.plugin.sendData(this.prepare1)
+          const result2 = await this.plugin.sendData(this.prepare2)
+
+          assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_REJECT)
+          assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
+          assert.equal(callCount, 2)
+        })
+
+        it.skip('should track payment ids separately for each token / sender')
       })
     })
-  })
-
-  describe('multiple chunks', function () {
-    beforeEach(async function () {
-      await this.receiver.connect()
-      const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
-      this.destinationAccount = destinationAccount
-      this.sharedSecret = sharedSecret
-      const pskRequest1 = encoding.serializePskPacket(sharedSecret, {
-        type: 0,
-        paymentId: Buffer.alloc(16),
-        sequence: 0,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment1 = condition.dataToFulfillment(sharedSecret, pskRequest1)
-      const executionCondition1 = condition.fulfillmentToCondition(fulfillment1)
-      this.prepare1 = IlpPacket.serializeIlpPrepare({
-        destination: destinationAccount,
-        amount: '100',
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition1,
-        data: pskRequest1
-      })
-      const pskRequest2 = encoding.serializePskPacket(sharedSecret, {
-        type: 0,
-        paymentId: Buffer.alloc(16),
-        sequence: 1,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment2 = condition.dataToFulfillment(sharedSecret, pskRequest2)
-      const executionCondition2 = condition.fulfillmentToCondition(fulfillment2)
-      this.prepare2 = IlpPacket.serializeIlpPrepare({
-        destination: destinationAccount,
-        amount: '200',
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition2,
-        data: pskRequest2
-      })
-    })
-
-    it('should call the payment handler on the first chunk', async function () {
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler(spy)
-      await this.plugin.sendData(this.prepare1)
-      assert.typeOf(spy.args[0][0].accept, 'function')
-      assert.typeOf(spy.args[0][0].reject, 'function')
-      assert.typeOf(spy.args[0][0].acceptSingleChunk, 'function')
-      assert.typeOf(spy.args[0][0].rejectSingleChunk, 'function')
-      assert.typeOf(spy.args[0][0].prepare, 'object')
-      assert.equal(spy.args[0][0].prepare.amount, '50')
-      assert(Buffer.isBuffer(spy.args[0][0].id))
-    })
-
-    it('should accept the next chunks if the receiver calls accpet', async function () {
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        params.accept()
-        spy()
-      })
-      const result1 = await this.plugin.sendData(this.prepare1)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(spy.callCount, 1)
-    })
-
-    it('should resolve the Promise returned by the accept function when the payment has been fully received', async function () {
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler(async (params: PaymentHandlerParams) => {
-        const paymentResult = await params.accept()
-        spy(paymentResult)
-      })
-
-      const pskRequest = encoding.serializePskPacket(this.sharedSecret, {
-        type: 0,
-        paymentId: Buffer.alloc(16),
-        sequence: 2,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
-      const executionCondition = condition.fulfillmentToCondition(fulfillment)
-      const prepare3 = IlpPacket.serializeIlpPrepare({
-        destination: this.destinationAccount,
-        amount: '1002', // plugin applies 0.5 exchange rate
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition,
-        data: pskRequest
-      })
-
-      const result1 = await this.plugin.sendData(this.prepare1)
-      const result2 = await this.plugin.sendData(this.prepare2)
-      const result3 = await this.plugin.sendData(prepare3)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result3[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-
-      // The payment result promise is resolved without being awaited so it'll only happen on the next tick of the event loop
-      await new Promise((resolve, reject) => setImmediate(resolve))
-
-      assert.equal(spy.callCount, 1)
-      assert.deepEqual(spy.args[0][0], {
-        id: Buffer.alloc(16),
-        chunksFulfilled: 3,
-        chunksRejected: 0,
-        expectedAmount: '500',
-        receivedAmount: '651'
-      })
-    })
-
-    it('should reject all chunks if the receiver calls reject', async function () {
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        spy()
-        params.reject('nop')
-      })
-      const result1 = await this.plugin.sendData(this.prepare1)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_REJECT)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
-      assert.equal(spy.callCount, 1)
-    })
-
-    it('should not accept any more chunks after the payment amount has been received', async function () {
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        params.accept()
-      })
-      const pskRequest = encoding.serializePskPacket(this.sharedSecret, {
-        type: 0,
-        paymentId: Buffer.alloc(16),
-        sequence: 0,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
-      const executionCondition = condition.fulfillmentToCondition(fulfillment)
-      const prepare = IlpPacket.serializeIlpPrepare({
-        destination: this.destinationAccount,
-        amount: '1002', // plugin applies 0.5 exchange rate
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition,
-        data: pskRequest
-      })
-      const result1 = await this.plugin.sendData(prepare)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
-    })
-
-    it('should not accept more chunks after the last chunk has been received', async function () {
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        params.accept()
-      })
-      const pskRequest = encoding.serializePskPacket(this.sharedSecret, {
-        type: 1, // last chunk
-        paymentId: Buffer.alloc(16),
-        sequence: 0,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
-      const executionCondition = condition.fulfillmentToCondition(fulfillment)
-      const prepare = IlpPacket.serializeIlpPrepare({
-        destination: this.destinationAccount,
-        amount: '100',
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition,
-        data: pskRequest
-      })
-      const result1 = await this.plugin.sendData(prepare)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_REJECT)
-    })
-
-    it('should accept one chunk and call the payment handler again if the user calls acceptSingleChunk', async function () {
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        params.acceptSingleChunk()
-        spy()
-      })
-      const result1 = await this.plugin.sendData(this.prepare1)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(spy.callCount, 2)
-    })
-
-    it('should accept a single-chunk payment if the user calls acceptSingleChunk', async function () {
-      // Previously this would throw because the finishedPromise was only set by the accept method, not acceptSingleChunk
-      const spy = sinon.spy()
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        params.acceptSingleChunk()
-        spy()
-      })
-      const pskRequest = encoding.serializePskPacket(this.sharedSecret, {
-        type: 1, // last chunk
-        paymentId: Buffer.alloc(16),
-        sequence: 0,
-        paymentAmount: new BigNumber(500),
-        chunkAmount: new BigNumber(0),
-        applicationData: Buffer.alloc(0)
-      })
-      const fulfillment = condition.dataToFulfillment(this.sharedSecret, pskRequest)
-      const executionCondition = condition.fulfillmentToCondition(fulfillment)
-      const prepare = IlpPacket.serializeIlpPrepare({
-        destination: this.destinationAccount,
-        amount: '100',
-        expiresAt: new Date(Date.now() + 2000),
-        executionCondition: executionCondition,
-        data: pskRequest
-      })
-      const result1 = await this.plugin.sendData(prepare)
-      assert.equal(spy.callCount, 1)
-    })
-
-    it('should reject one chunk and call the payment handler again if the user calls rejectSingleChunk', async function () {
-      let callCount = 0
-      this.receiver.registerPaymentHandler((params: PaymentHandlerParams) => {
-        if (++callCount === 1) {
-          params.rejectSingleChunk('nope')
-        } else {
-          params.acceptSingleChunk()
-        }
-      })
-      const result1 = await this.plugin.sendData(this.prepare1)
-      const result2 = await this.plugin.sendData(this.prepare2)
-
-      assert.equal(result1[0], IlpPacket.Type.TYPE_ILP_REJECT)
-      assert.equal(result2[0], IlpPacket.Type.TYPE_ILP_FULFILL)
-      assert.equal(callCount, 2)
-    })
-
-    it.skip('should track payment ids separately for each token / sender')
   })
 })
 

--- a/test/receiver.test.ts
+++ b/test/receiver.test.ts
@@ -63,7 +63,7 @@ describe('Receiver', function () {
       assert(false, 'should not get here')
     })
 
-    it('should append the receiver ID and token to the address returned by ILDCP', async function () {
+    it('should append the token to the address returned by ILDCP', async function () {
       await this.receiver.connect()
       const { destinationAccount, sharedSecret } = this.receiver.generateAddressAndSecret()
       assert.match(destinationAccount, /^test\.receiver\.[a-zA-Z0-9_-]+$/)

--- a/test/sender.test.ts
+++ b/test/sender.test.ts
@@ -68,6 +68,24 @@ describe('Sender', function () {
       assert.equal((result as sender.PskResponse).destinationAmount.toString(10), '5')
     })
 
+    it('should send an unfulfillable request that is rejected by the receiver', async function () {
+      const receiver = await createReceiver({
+        plugin: this.plugin,
+        requestHandler: (params: RequestHandlerParams) => { params.accept(Buffer.from('thanks!')) }
+      })
+      const { destinationAccount, sharedSecret } = receiver.generateAddressAndSecret()
+
+      const result = await sender.sendRequest(this.plugin, {
+        destinationAccount,
+        sharedSecret,
+        sourceAmount: '10',
+        unfulfillableCondition: Buffer.alloc(32, 0)
+      })
+      assert.equal(result.fulfilled, false)
+      assert.equal(result.data.toString('utf8'), '')
+      assert.equal(result.destinationAmount.toString(10), '5')
+    })
+
     it('should return the data the receiver passes back when rejecting the packet', async function () {
       const receiver = await createReceiver({
         plugin: this.plugin,

--- a/test/sender.test.ts
+++ b/test/sender.test.ts
@@ -63,6 +63,7 @@ describe('Sender', function () {
         sourceAmount: '10',
         minDestinationAmount: '1'
       })
+      assert.equal(result.fulfilled, true)
       assert.equal(result.data.toString('utf8'), 'thanks!')
       assert.equal((result as sender.PskResponse).destinationAmount.toString(10), '5')
     })
@@ -80,6 +81,7 @@ describe('Sender', function () {
         sourceAmount: '10',
         minDestinationAmount: '1'
       })
+      assert.equal(result.fulfilled, false)
       assert.equal(result.data.toString('utf8'), 'nope')
       assert.equal(result.destinationAmount.toString(10), '5')
     })
@@ -106,6 +108,7 @@ describe('Sender', function () {
       })
       assert(stub.calledOnce)
       assert.deepEqual(IlpPacket.deserializeIlpPrepare(stub.args[0][0]).executionCondition, QUOTE_CONDITION)
+      assert.equal(result.fulfilled, false)
       assert.equal(result.destinationAmount.toString(10), '5')
       assert.equal(result.data.toString('utf8'), 'hello')
     })
@@ -132,6 +135,7 @@ describe('Sender', function () {
       })
       assert(stub.calledOnce)
       assert.deepEqual(IlpPacket.deserializeIlpPrepare(stub.args[0][0]).executionCondition, Buffer.alloc(32))
+      assert.equal(result.fulfilled, false)
       assert.equal(result.destinationAmount.toString(10), '5')
       assert.equal(result.data.toString('utf8'), 'hello')
     })
@@ -179,6 +183,7 @@ describe('Sender', function () {
         requestId: 1234
       }) as sender.PskError
       assert(stub.calledOnce)
+      assert.equal(result.fulfilled, false)
       assert.equal(result.code, 'F99')
       assert.equal(result.destinationAmount.toString(10), '0')
       assert.equal(result.data.toString('utf8'), '')
@@ -204,6 +209,7 @@ describe('Sender', function () {
         requestId: 1234
       }) as sender.PskError
       assert(stub.calledOnce)
+      assert.equal(result.fulfilled, false)
       assert.equal(result.code, 'F99')
       assert.equal(result.destinationAmount.toString(10), '0')
       assert.equal(result.data.toString('utf8'), '')
@@ -229,6 +235,7 @@ describe('Sender', function () {
         requestId: 1234
       }) as sender.PskError
       assert(stub.calledOnce)
+      assert.equal(result.fulfilled, false)
       assert.equal(result.code, 'F99')
       assert.equal(result.destinationAmount.toString(10), '0')
       assert.equal(result.data.toString('utf8'), '')
@@ -244,6 +251,7 @@ describe('Sender', function () {
         sourceAmount: '10',
         unfulfillableCondition: 'random'
       }) as sender.PskError
+      assert.equal(result.fulfilled, false)
       assert.equal(result.destinationAmount.toString(10), '5')
     })
 
@@ -256,6 +264,7 @@ describe('Sender', function () {
         ...receiver.generateAddressAndSecret(),
         sourceAmount: '10'
       }) as sender.PskResponse
+      assert.equal(result.fulfilled, true)
       assert.equal(result.destinationAmount.toString(10), '5')
     })
   })

--- a/test/sender.test.ts
+++ b/test/sender.test.ts
@@ -104,7 +104,7 @@ describe('Sender', function () {
         sharedSecret: SHARED_SECRET,
         sourceAmount: '10',
         requestId: 1234,
-        unfulfillableCondition: 'random'
+        unfulfillableCondition: QUOTE_CONDITION
       })
       assert(stub.calledOnce)
       assert.deepEqual(IlpPacket.deserializeIlpPrepare(stub.args[0][0]).executionCondition, QUOTE_CONDITION)
@@ -131,7 +131,7 @@ describe('Sender', function () {
         sharedSecret: SHARED_SECRET,
         sourceAmount: '10',
         requestId: 1234,
-        unfulfillableCondition: 'zeros'
+        unfulfillableCondition: Buffer.alloc(32)
       })
       assert(stub.calledOnce)
       assert.deepEqual(IlpPacket.deserializeIlpPrepare(stub.args[0][0]).executionCondition, Buffer.alloc(32))
@@ -249,7 +249,7 @@ describe('Sender', function () {
       const result = await sender.sendRequest(this.plugin, {
         ...receiver.generateAddressAndSecret(),
         sourceAmount: '10',
-        unfulfillableCondition: 'random'
+        unfulfillableCondition: crypto.randomBytes(32)
       }) as sender.PskError
       assert.equal(result.fulfilled, false)
       assert.equal(result.destinationAmount.toString(10), '5')

--- a/test/sender.test.ts
+++ b/test/sender.test.ts
@@ -55,7 +55,7 @@ describe('Sender', function () {
         code: 'F99',
         message: '',
         triggeredBy: 'test.receiver',
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 3,
           sequence: 0,
           paymentId: PAYMENT_ID,
@@ -78,7 +78,7 @@ describe('Sender', function () {
         amount: '10',
         executionCondition: QUOTE_CONDITION,
         expiresAt: new Date(30000),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 1,
           paymentId: PAYMENT_ID,
           sequence: 0,
@@ -107,7 +107,7 @@ describe('Sender', function () {
         code: 'F99',
         message: '',
         triggeredBy: 'test.receiver',
-        data: encoding.serializePskPacket(wrongSecret, {
+        data: encoding.serializeLegacyPskPacket(wrongSecret, {
           type: 3,
           sequence: 0,
           paymentId: PAYMENT_ID,
@@ -157,7 +157,7 @@ describe('Sender', function () {
         code: 'F99',
         message: '',
         triggeredBy: 'test.receiver',
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 3,
           sequence: 0,
           paymentId: PAYMENT_ID,
@@ -180,7 +180,7 @@ describe('Sender', function () {
         amount: '1000',
         executionCondition: QUOTE_CONDITION,
         expiresAt: new Date(30000),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 1,
           paymentId: PAYMENT_ID,
           sequence: 0,
@@ -208,7 +208,7 @@ describe('Sender', function () {
     beforeEach(function () {
       this.plugin.sendData = (buffer: Buffer) => Promise.resolve(IlpPacket.serializeIlpFulfill({
         fulfillment: Buffer.from('0de77e566fd39f0b9ea26bb10e4b6aa3ff813eee37758caf0c1adfd69edd572b', 'hex'),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 2,
           paymentId: PAYMENT_ID,
           sequence: 0,
@@ -234,7 +234,7 @@ describe('Sender', function () {
         amount: '100',
         executionCondition: Buffer.from('dbe5899c51056feae0d6b42dc8677f40a5452ca03512f058d95132c2cf5b7bf8', 'hex'),
         expiresAt: new Date(30000),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 1,
           paymentId: PAYMENT_ID,
           sequence: 0,
@@ -250,7 +250,7 @@ describe('Sender', function () {
       const stub = sinon.stub(this.plugin, 'sendData')
         .resolves(IlpPacket.serializeIlpFulfill({
           fulfillment: Buffer.from('W1FuCUSj7DXLzQMGlWC7HxbTHs6jOVRtAh5uITnmzWY=', 'base64'),
-          data: encoding.serializePskPacket(SHARED_SECRET, {
+          data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
             type: 2,
             paymentId: Buffer.alloc(16, 5),
             sequence: 5,
@@ -274,7 +274,7 @@ describe('Sender', function () {
         amount: '100',
         executionCondition: Buffer.from('3b06f0bb996ebfebc485ba91418b59e99fa8b0ab610670df1c1a13c34d416c57', 'hex'),
         expiresAt: new Date(30000),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 0,
           paymentId: Buffer.alloc(16, 5),
           sequence: 5,
@@ -325,7 +325,7 @@ describe('Sender', function () {
         code: 'F99',
         message: '',
         triggeredBy: 'test.receiver',
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 3,
           paymentId: PAYMENT_ID,
           sequence: 0,
@@ -416,7 +416,7 @@ describe('Sender', function () {
     it('rejects if the PSK response packet sequence does not correspond to the request', async function () {
       this.plugin.sendData = (buffer: Buffer) => Promise.resolve(IlpPacket.serializeIlpFulfill({
         fulfillment: Buffer.from('Ded+Vm/TnwueomuxDktqo/+BPu43dYyvDBrf1p7dVys=', 'base64'),
-        data: encoding.serializePskPacket(SHARED_SECRET, {
+        data: encoding.serializeLegacyPskPacket(SHARED_SECRET, {
           type: 3,
           paymentId: PAYMENT_ID,
           sequence: 5,


### PR DESCRIPTION
Implements https://github.com/interledger/rfcs/pull/384

As described in [this gist](https://gist.github.com/emschwartz/235ac5bdfcd0a6b07315a248c0cd84ee), PSK2 should not have chunked payments-specific features. Instead, it should provide a simple building block based on individual requests/responses that can be used for quoting, single payments, and (as part of another protocol/module) chunked payments.

This PR deprecates all of the sender methods and the `Receiver.registerPaymentHandler` in favor of `sendRequest` on the sending side and `Receiver.registerRequestHandler` on the receiving side. It also allows application data to be transmitted in the request and the response.

This change is backwards compatible, both in terms of the module API and the protocol. Functionality is deprecated but not yet removed from the module. Both the sending and receiving sides will fall back to using the old PSK2 packets if the new ones do not work. This backwards compatibility should be removed in the next release of this module (probably 1.0.0).

resolves #5, resolves #6, resolves #13, resolves #17, resolves #18